### PR TITLE
Fix SSL handshakes due to lack of CA root certs

### DIFF
--- a/face/face.py
+++ b/face/face.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from FACe_signer.FACe import FACe_signer
 import zeep
+from request import Session
+import certifi
 import os.path
 from .services import Invoice, NIF, Administration
 import re
@@ -49,10 +51,16 @@ class FACe(object):
             assert kwargs['environment'] in FACE_ENVS.keys(), "Provided environment '{}' not recognized in defined FACE_ENVS {}".format(kwargs['environment'], str(FACE_ENVS.keys()))
             self.environment = kwargs['environment']
 
+            
+        # Inject updated CA root certs for the transport layer
+        updated_session = Sessions()
+        updated_session.verify = certifi.where()
+        transport = zeep.transports.Tranport(session=updated_session)
         # initialize a ZEEP client with the desired FACe envs
         self.client = zeep.Client(
             FACE_ENVS[self.environment],
-            plugins=[FACe_signer(self.certificate, debug=self.debug)]
+            plugins=[FACe_signer(self.certificate, debug=self.debug)],
+            transport=transport
         )
 
         # Initialitze specific services handlers

--- a/face/face.py
+++ b/face/face.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from FACe_signer.FACe import FACe_signer
 import zeep
-from request import Session
+from requests import Session
 import certifi
 import os.path
 from .services import Invoice, NIF, Administration

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ FACe_signer
 zeep
 marshmallow
 certifi
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 FACe_signer
 zeep
 marshmallow
+certifi


### PR DESCRIPTION
Fixed with @gdalmau :chocolate_bar: 

It uses the `certifi` pacakge to ensure that major CAs are correctly validated.

The Zeep client transport has been fixed to ensure that the validator of the session takes care about those new CA certificates.

Fix #9 Review SSL v3 verification incident  