### PR TITLE
NEW add attachments on sending an invoice

### DIFF
--- a/face/services/invoice.py
+++ b/face/services/invoice.py
@@ -23,9 +23,9 @@ class Invoice(SOAP_Service):
         schema = InvoiceSchema()
         return schema.load(call_result)
 
-    def send(self, invoice):
+    def send(self, invoice, attachments=None):
         """
-        Send an invoice and return the delivery result
+        Send an invoice with optional attachments and return the delivery result
 
         It prepares the payload wanted for the `enviarFactura` webservice with a base64 invoice and their filename
         """
@@ -38,6 +38,9 @@ class Invoice(SOAP_Service):
                 "mime": "application/xml",
             }
         }
+        if attachments:
+            the_invoice['anexos'] = attachments
+
         call_result = self.serialize(self.service.enviarFactura(the_invoice))
         schema = InvoiceSchema()
         return schema.load(call_result)


### PR DESCRIPTION
Add a parameter to send attachments along with the invoice. It works as follow:

```python
invoice = ...
attachments = [{
    'anexo': {
        'anexo': base64_pdf_file,
        'mime': 'application/pdf',
        'nombre': 'adjunto_ejemplo.pdf'
    }
}]
result = face.invoices.send(invoice=invoice, attachments=attachments)
```