### PR TITLE
Changes on send and reception FACe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 certs/*
+.idea/*

--- a/face/face.py
+++ b/face/face.py
@@ -13,6 +13,12 @@ FACE_ENVS = {
     'staging': "https://se-face-webservice.redsara.es/facturasspp2?wsdl",
 }
 
+EFACT_ENVS = {
+    'prod': "https://efact.aoc.cat/bustia/services/EFactWebServiceProxyService.wsdl",
+    'staging': "https://efact-pre.aoc.cat/bustia/services/EFactWebServiceProxyService.wsdl",
+}
+
+
 class FACe(object):
     """
     FACe object
@@ -46,9 +52,16 @@ class FACe(object):
 
         # Handle environment, df "prod"
         self.environment = "prod"
+        self.destination = kwargs.get('destination', 'FACE')
+        if self.destination == 'FACE':
+            destination = FACE_ENVS
+        elif self.destination == 'EFACT':
+            destination = EFACT_ENVS
+        else:
+            raise Exception("Environment isn't correct. It must be FACE or EFACT")
         if 'environment' in kwargs:
             assert type(kwargs['environment']) == str, "environment argument must be an string"
-            assert kwargs['environment'] in FACE_ENVS.keys(), "Provided environment '{}' not recognized in defined FACE_ENVS {}".format(kwargs['environment'], str(FACE_ENVS.keys()))
+            assert kwargs['environment'] in destination.keys(), "Provided environment '{}' not recognized in defined destination {}".format(kwargs['environment'], str(destination.keys()))
             self.environment = kwargs['environment']
 
         self.result_obj = kwargs.get('result_obj', False)
@@ -59,7 +72,7 @@ class FACe(object):
         transport = zeep.transports.Transport(session=updated_session)
         # initialize a ZEEP client with the desired FACe envs
         self.client = zeep.Client(
-            FACE_ENVS[self.environment],
+            destination[self.environment],
             plugins=[FACe_signer(self.certificate, debug=self.debug)],
             transport=transport
         )

--- a/face/face.py
+++ b/face/face.py
@@ -51,6 +51,7 @@ class FACe(object):
             assert kwargs['environment'] in FACE_ENVS.keys(), "Provided environment '{}' not recognized in defined FACE_ENVS {}".format(kwargs['environment'], str(FACE_ENVS.keys()))
             self.environment = kwargs['environment']
 
+        self.result_obj = kwargs.get('result_obj', False)
             
         # Inject updated CA root certs for the transport layer
         updated_session = Session()
@@ -64,6 +65,6 @@ class FACe(object):
         )
 
         # Initialitze specific services handlers
-        self.invoices = Invoice(service=self.client.service, email=self.email)
-        self.nifs = NIF(service=self.client.service)
-        self.administrations = Administration(service=self.client.service)
+        self.invoices = Invoice(service=self.client.service, email=self.email, result_obj=self.result_obj)
+        self.nifs = NIF(service=self.client.service, result_obj=self.result_obj)
+        self.administrations = Administration(service=self.client.service, result_obj=self.result_obj)

--- a/face/face.py
+++ b/face/face.py
@@ -13,12 +13,6 @@ FACE_ENVS = {
     'staging': "https://se-face-webservice.redsara.es/facturasspp2?wsdl",
 }
 
-EFACT_ENVS = {
-    'prod': "https://efact.aoc.cat/bustia/services/EFactWebServiceProxyService.wsdl",
-    'staging': "https://efact-pre.aoc.cat/bustia/services/EFactWebServiceProxyService.wsdl",
-}
-
-
 class FACe(object):
     """
     FACe object
@@ -55,10 +49,8 @@ class FACe(object):
         self.destination = kwargs.get('destination', 'FACE')
         if self.destination == 'FACE':
             destination = FACE_ENVS
-        elif self.destination == 'EFACT':
-            destination = EFACT_ENVS
         else:
-            raise Exception("Environment isn't correct. It must be FACE or EFACT")
+            raise Exception("Environment isn't correct. It must be FACE")
         if 'environment' in kwargs:
             assert type(kwargs['environment']) == str, "environment argument must be an string"
             assert kwargs['environment'] in destination.keys(), "Provided environment '{}' not recognized in defined destination {}".format(kwargs['environment'], str(destination.keys()))

--- a/face/services/administration.py
+++ b/face/services/administration.py
@@ -7,6 +7,10 @@ class Administration(SOAP_Service):
     Integrate all NIF-related methods
     """
 
+    def __init__(self, service, result_obj=False):
+        super(Administration, self).__init__(service)
+        self.result_obj = result_obj
+
     def list(self):
         """
         List administrations

--- a/face/services/invoice.py
+++ b/face/services/invoice.py
@@ -8,9 +8,10 @@ class Invoice(SOAP_Service):
     """
     Integrate all invoice-related methods
     """
-    def __init__(self, service, email):
+    def __init__(self, service, email, result_obj=False):
         super(Invoice, self).__init__(service)
         self.email = email
+        self.result_obj = result_obj
 
     def fetch(self, invoice):
         """
@@ -21,7 +22,10 @@ class Invoice(SOAP_Service):
         assert type(invoice) in [int, str], "Invoice must be the registry number of the sended invoice."
         call_result = self.serialize(self.service.consultarFactura(numeroRegistro=str(invoice)))
         schema = InvoiceSchema()
-        return schema.load(call_result)
+        if self.result_obj:
+            return schema.load(call_result)
+        else:
+            return call_result
 
     def send(self, invoice, attachments=None):
         """
@@ -43,7 +47,10 @@ class Invoice(SOAP_Service):
 
         call_result = self.serialize(self.service.enviarFactura(the_invoice))
         schema = InvoiceSchema()
-        return schema.load(call_result)
+        if self.result_obj:
+            return schema.load(call_result)
+        else:
+            return call_result
 
     def cancel(self, invoice, reason):
         """
@@ -61,7 +68,10 @@ class Invoice(SOAP_Service):
 
         call_result = self.serialize(self.service.anularFactura(**the_invoice))
         schema = InvoiceSchema()
-        return schema.load(call_result)
+        if self.result_obj:
+            return schema.load(call_result)
+        else:
+            return call_result
 
     def list_states(self):
         """
@@ -74,4 +84,7 @@ class Invoice(SOAP_Service):
 
         call_result = self.serialize(self.service.consultarEstados())
         schema = StatusesSchema()
-        return schema.load(call_result)
+        if self.result_obj:
+            return schema.load(call_result)
+        else:
+            return call_result

--- a/face/services/invoice.py
+++ b/face/services/invoice.py
@@ -27,18 +27,23 @@ class Invoice(SOAP_Service):
         else:
             return call_result
 
-    def send(self, invoice, attachments=None):
+    def send_by_filename(self, invoice, attachments=None):
+        assert type(invoice) == str, "Invoice must be the filename of the invoice to deliver"
+        invoice_content = base64.b64encode(open(invoice).read())
+        invoice_filename = os.path.basename(invoice)
+        return self.send(invoice_filename, invoice_content, attachments=attachments)
+
+    def send(self, invoice_filename, invoice_content, attachments=None):
         """
         Send an invoice with optional attachments and return the delivery result
 
         It prepares the payload wanted for the `enviarFactura` webservice with a base64 invoice and their filename
         """
-        assert type(invoice) == str, "Invoice must be the filename of the invoice to deliver"
         the_invoice = {
             "correo": self.email,
             "factura": {
-                "factura": base64.b64encode(open(invoice).read()),
-                "nombre": os.path.basename(invoice),
+                "factura": invoice_content,
+                "nombre": invoice_filename,
                 "mime": "application/xml",
             }
         }

--- a/face/services/nif.py
+++ b/face/services/nif.py
@@ -7,6 +7,10 @@ class NIF(SOAP_Service):
     Integrate all NIF-related methods
     """
 
+    def __init__(self, service, result_obj=False):
+        super(NIF, self).__init__(service)
+        self.result_obj = result_obj
+
     def list(self):
         """
         List NIFs method.
@@ -16,4 +20,7 @@ class NIF(SOAP_Service):
         call_result = self.serialize(self.service.consultarNIFs())
 
         schema = ResponseSchema()
-        return schema.load(call_result)
+        if self.result_obj:
+            return schema.load(call_result)
+        else:
+            return call_result


### PR DESCRIPTION
Breaks Compatibilities:

**send** method changes. 

- Previous behavior has respected in a new function `send_by_filename` who has the same parameters. 
- New behavior
  - invoice_filename: Filename of the invoice
  - invoice_content: b64encoded content of the file who want to send
  - attachments: Same as previous behavior 

**Return values**
- By Default return values are directly from response and not return specific objects.
- Compatibility with previous behavior is so easy. Only need to pass a new parameter on init on kwargs parameters with `result_obj=True`
     ```
      ...
     face = FACe(
            environment=self.environment,
            certificate=self.certificate,
            email=self.email, 
            result_obj=True
        )
     ``` 
